### PR TITLE
Fully working twitter bot with npm module solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.js
 node_modules
+wpt.config.js

--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,8 @@
 var Twit = require('twit'),
   T = new Twit(require('./config.js'));
 
+var wptKey = require('./wpt.config.js').k;
+
 var querystring = require('querystring'),
     http = require('http'),
     fs = require('fs');
@@ -69,7 +71,7 @@ T.get('account/verify_credentials', { skip_status: true })
     var post_data = querystring.stringify({
       'url': urlToTest,
       'f': 'xml',
-      'k': 'Need to put in your api key from webpagetest'
+      'k': wptKey
     });
 
     var post_options = {

--- a/bot.js
+++ b/bot.js
@@ -1,7 +1,13 @@
 var Twit = require('twit'),
   T = new Twit(require('./config.js'));
 
+var querystring = require('querystring'),
+    http = require('http'),
+    fs = require('fs');
 
+var parseString = require('xml2js').parseString;
+
+var JSON = require('JSON');
 
 T.get('account/verify_credentials', { skip_status: true })
 .catch(function (err) {
@@ -14,7 +20,7 @@ T.get('account/verify_credentials', { skip_status: true })
   // See https://github.com/ttezel/twit#tgetpath-params-callback 
   // for details. 
 
-  console.log('data', result.data);
+  //console.log('data', result.data);
   return (result.data.screen_name);
 }).then(function(botName) {
   var stream = T.stream('statuses/filter', {
@@ -43,19 +49,59 @@ T.get('account/verify_credentials', { skip_status: true })
   stream.on('tweet', function(message) {
     var screenName = message.user.screen_name;
 
-    console.log(message);
+    //console.log(message);
 
     // Return when the account has replied to itself and prevent infinite loops
     if (screenName === botName) {
       return;
     }
 
-    T.post('statuses/update', {
-      status: 'I hear you @' + screenName,
-      in_reply_to_status_id: message.id_str
-    }, function(err, data, response) {
-      // console.log(data)
-    })
+    var reURL = /(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?/gm;
+
+    console.log('URL: ', message.text.match(reURL)[0].split(' ')[0]);
+
+    var urlToTest = message.text.match(reURL)[0].split(' ')[0];
+
+    if (!urlToTest) {
+      return;
+    }
+
+    var post_data = querystring.stringify({
+      'url': urlToTest,
+      'f': 'xml',
+      'k': 'Need to put in your api key from webpagetest'
+    });
+
+    var post_options = {
+      host: 'www.webpagetest.org',
+      path: '/runtest.php',
+      port: '80',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': Buffer.byteLength(post_data)
+      }
+    };
+
+    var post_req = http.request(post_options, function(res) {
+      res.setEncoding('utf8');
+      res.on('data', function (chunk) {
+          console.log('Response: ' + chunk);
+          parseString(chunk, function (err, result) {
+            var resultUrl = JSON.parse(JSON.stringify(result)).response.data[0].userUrl[0]
+            T.post('statuses/update', {
+              status: 'No problem @' + screenName + '.  I submitted the test for ' + urlToTest + ' to www.webpagetest.org, check the result at ' + resultUrl,
+              in_reply_to_status_id: message.id_str
+            }, function(err, data, response) {
+              // console.log(data)
+            })
+          });
+      });
+    });
+
+    // post the data
+    post_req.write(post_data);
+    post_req.end();
 
     // stream.stop();
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,11 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -67,6 +72,20 @@
         "hoek": "4.2.0"
       }
     },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -84,6 +103,19 @@
       "requires": {
         "delayed-stream": "1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
+      "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA==",
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -108,6 +140,35 @@
         }
       }
     },
+    "csv": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-1.2.1.tgz",
+      "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
+      "requires": {
+        "csv-generate": "1.1.2",
+        "csv-parse": "1.3.3",
+        "csv-stringify": "1.1.2",
+        "stream-transform": "0.2.2"
+      }
+    },
+    "csv-generate": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-1.1.2.tgz",
+      "integrity": "sha1-7GsA7a7W5ZrZwgWC9MNk4osUYkA="
+    },
+    "csv-parse": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.3.3.tgz",
+      "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
+    },
+    "csv-stringify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
+      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+      "requires": {
+        "lodash.get": "4.4.2"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -116,10 +177,23 @@
         "assert-plus": "1.0.0"
       }
     },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -129,6 +203,16 @@
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "extend": {
       "version": "3.0.1",
@@ -165,6 +249,11 @@
         "mime-types": "2.1.17"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -172,6 +261,29 @@
       "requires": {
         "assert-plus": "1.0.0"
       }
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -187,6 +299,11 @@
         "har-schema": "2.0.0"
       }
     },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -197,6 +314,11 @@
         "hoek": "4.2.0",
         "sntp": "2.1.0"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "hoek": {
       "version": "4.2.0",
@@ -217,6 +339,20 @@
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -249,6 +385,11 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -258,6 +399,70 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "mime": {
@@ -278,10 +483,78 @@
         "mime-db": "1.30.0"
       }
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -365,10 +638,23 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "stream-transform": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.2.2.tgz",
+      "integrity": "sha1-dYZ0h/SVKPi/HYJJllh1PQLfeDg="
+    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "requires": {
+        "has-flag": "1.0.0"
+      }
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -416,6 +702,23 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
+    },
+    "webpagetest": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/webpagetest/-/webpagetest-0.3.8.tgz",
+      "integrity": "sha1-KzdeYbr3bD7VB9gwSTNq+P8XEp8=",
+      "requires": {
+        "commander": "2.10.0",
+        "csv": "1.2.1",
+        "entities": "1.1.1",
+        "mocha": "3.5.3",
+        "xml2js": "0.4.19"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSON": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/JSON/-/JSON-1.0.0.tgz",
-      "integrity": "sha1-hoFTHCj4Q4oHVYn/BySCRuqWDYw="
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -325,11 +320,6 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
       "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
-    "http": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/http/-/http-0.0.0.tgz",
-      "integrity": "sha1-huYybSnF0Dnen6xYSkVon5KfT3I="
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -570,11 +560,6 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "request": {
       "version": "2.83.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSON": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/JSON/-/JSON-1.0.0.tgz",
+      "integrity": "sha1-hoFTHCj4Q4oHVYn/BySCRuqWDYw="
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -198,6 +203,11 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
       "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
+    "http": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/http/-/http-0.0.0.tgz",
+      "integrity": "sha1-huYybSnF0Dnen6xYSkVon5KfT3I="
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -288,6 +298,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
@@ -321,6 +336,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "sntp": {
       "version": "2.1.0",
@@ -396,6 +416,20 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "http": "0.0.0",
     "querystring": "^0.2.0",
     "twit": "^2.2.5",
+    "webpagetest": "^0.3.8",
     "xml2js": "^0.4.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   },
   "homepage": "https://github.com/sergeychernyshev/web-speed-bot#readme",
   "dependencies": {
-    "twit": "^2.2.5"
+    "JSON": "^1.0.0",
+    "http": "0.0.0",
+    "querystring": "^0.2.0",
+    "twit": "^2.2.5",
+    "xml2js": "^0.4.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,7 @@
   },
   "homepage": "https://github.com/sergeychernyshev/web-speed-bot#readme",
   "dependencies": {
-    "JSON": "^1.0.0",
-    "http": "0.0.0",
-    "querystring": "^0.2.0",
     "twit": "^2.2.5",
-    "webpagetest": "^0.3.8",
-    "xml2js": "^0.4.19"
+    "webpagetest": "^0.3.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Twitter bot that will test sites for speed when you copy it on messages that have URLs.",
   "main": "bot.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node bot.js"
   },
   "repository": {
     "type": "git",

--- a/wpt.config.sample.js
+++ b/wpt.config.sample.js
@@ -1,0 +1,6 @@
+/**
+ * Get your API key here --> https://www.webpagetest.org/getkey.php
+ */
+module.exports = {
+  k: 'Your Web Page Test API Key Goes Here'
+}


### PR DESCRIPTION
#  Successful URL detection in tweet, send to webpagetest, and tweet back result URL

Added: URLs are now detected as substrings in tweets.

Added: Recognized URLs are now sent to webpagetest for performance analysis.

Added: webpagetest result URLs are now tweeted back to the original tweeter.


# Setting Web Page Test Config Files

.gitignore - Added: .gitignore file now ignores the wpt.config.js file (make it from the wpt.config.sample.js)

package.json - Changed: 'test' command is now replaced by a default 'start' command (run with npm start).

wpt.config.sample.js - Added: New file that holds your Web Page Test API key.

bot.js - Changed: The Web Page Test key is now pulled from the config file wpt.config.js


# Converted solution from HTTP RESTful endpoint to npm module

Removed: All dependencies besides Twit is now replaced with the webpagetest npm module.

Added: Much more functionality is commented.

Changed: Functionality is now the same with a much cleaner solution by the webpagetest npm module.